### PR TITLE
Handle social media image pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "node-fetch": "^2.6.7"
   },
   "engines": {
-    "node": "16.x"
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
## Summary
- retrieve images through page metadata when links are from Facebook or Instagram
- randomize search start index for less predictable results
- update Node engine requirement to v18

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `node -e "const f=require('./api/media'); f({query:{search:'cat'}},{status:c=>({json:obj=>console.log('STATUS',c,obj),send:console.log,setHeader:()=>{}})})"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_6858e2e4e85c83289fbf3f7bbc628513